### PR TITLE
8249192: MonitorInfo stores raw oops across safepoints

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -724,13 +724,13 @@ JvmtiEnvBase::get_locked_objects_in_frame(JavaThread* calling_thread, JavaThread
                                  javaVFrame *jvf, GrowableArray<jvmtiMonitorStackDepthInfo*>* owned_monitors_list, jint stack_depth) {
   jvmtiError err = JVMTI_ERROR_NONE;
   ResourceMark rm;
+  HandleMark hm;
 
   GrowableArray<MonitorInfo*>* mons = jvf->monitors();
   if (mons->is_empty()) {
     return err;  // this javaVFrame holds no monitors
   }
 
-  HandleMark hm;
   oop wait_obj = NULL;
   {
     // The ObjectMonitor* can't be async deflated since we are either
@@ -1026,7 +1026,6 @@ JvmtiEnvBase::get_object_monitor_usage(JavaThread* calling_thread, jobject objec
       // as lightweight locks before inflating the monitor are not included.
       // We have to count the number of recursive monitor entries the hard way.
       // We pass a handle to survive any GCs along the way.
-      ResourceMark rm;
       ret.entry_count = count_locked_objects(owning_thread, hobj);
     }
     // implied else: entry_count == 0

--- a/src/hotspot/share/prims/stackwalk.cpp
+++ b/src/hotspot/share/prims/stackwalk.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -288,6 +288,9 @@ void LiveFrameStream::fill_live_stackframe(Handle stackFrame,
                                            const methodHandle& method, TRAPS) {
   fill_stackframe(stackFrame, method, CHECK);
   if (_jvf != NULL) {
+    ResourceMark rm(THREAD);
+    HandleMark hm(THREAD);
+
     StackValueCollection* locals = _jvf->locals();
     StackValueCollection* expressions = _jvf->expressions();
     GrowableArray<MonitorInfo*>* monitors = _jvf->monitors();

--- a/src/hotspot/share/runtime/biasedLocking.cpp
+++ b/src/hotspot/share/runtime/biasedLocking.cpp
@@ -906,8 +906,8 @@ void BiasedLocking::preserve_marks() {
   _preserved_mark_stack = new (ResourceObj::C_HEAP, mtInternal) GrowableArray<markWord>(10, true);
   _preserved_oop_stack = new (ResourceObj::C_HEAP, mtInternal) GrowableArray<Handle>(10, true);
 
-  ResourceMark rm;
   Thread* cur = Thread::current();
+  ResourceMark rm(cur);
   for (JavaThreadIteratorWithHandle jtiwh; JavaThread *thread = jtiwh.next(); ) {
     if (thread->has_last_Java_frame()) {
       RegisterMap rm(thread);

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -1,5 +1,3 @@
-
-
 /*
  * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -218,6 +216,7 @@ static bool eliminate_allocations(JavaThread* thread, int exec_mode, CompiledMet
 }
 
 static void eliminate_locks(JavaThread* thread, GrowableArray<compiledVFrame*>* chunk, bool realloc_failures) {
+  HandleMark hm;
 #ifndef PRODUCT
   bool first = true;
 #endif
@@ -1542,6 +1541,8 @@ void Deoptimization::revoke_from_deopt_handler(JavaThread* thread, frame fr, Reg
   if (!UseBiasedLocking) {
     return;
   }
+  ResourceMark rm;
+  HandleMark hm;
   GrowableArray<Handle>* objects_to_revoke = new GrowableArray<Handle>();
   get_monitors_from_stack(objects_to_revoke, thread, fr, map);
 

--- a/src/hotspot/share/runtime/vframe.hpp
+++ b/src/hotspot/share/runtime/vframe.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@
 #include "code/location.hpp"
 #include "oops/oop.hpp"
 #include "runtime/frame.hpp"
+#include "runtime/handles.hpp"
 #include "runtime/stackValue.hpp"
 #include "runtime/stackValueCollection.hpp"
 #include "utilities/growableArray.hpp"
@@ -241,34 +242,22 @@ class entryVFrame: public externalVFrame {
 // 2) the monitor lock
 class MonitorInfo : public ResourceObj {
  private:
-  oop        _owner; // the object owning the monitor
+  Handle     _owner; // the object owning the monitor
   BasicLock* _lock;
-  oop        _owner_klass; // klass (mirror) if owner was scalar replaced
+  Handle     _owner_klass; // klass (mirror) if owner was scalar replaced
   bool       _eliminated;
   bool       _owner_is_scalar_replaced;
  public:
   // Constructor
-  MonitorInfo(oop owner, BasicLock* lock, bool eliminated, bool owner_is_scalar_replaced) {
-    if (!owner_is_scalar_replaced) {
-      _owner = owner;
-      _owner_klass = NULL;
-    } else {
-      assert(eliminated, "monitor should be eliminated for scalar replaced object");
-      _owner = NULL;
-      _owner_klass = owner;
-    }
-    _lock  = lock;
-    _eliminated = eliminated;
-    _owner_is_scalar_replaced = owner_is_scalar_replaced;
-  }
+  MonitorInfo(oop owner, BasicLock* lock, bool eliminated, bool owner_is_scalar_replaced);
   // Accessors
-  oop        owner() const {
+  oop owner() const {
     assert(!_owner_is_scalar_replaced, "should not be called for scalar replaced object");
-    return _owner;
+    return _owner();
   }
-  oop   owner_klass() const {
+  oop owner_klass() const {
     assert(_owner_is_scalar_replaced, "should not be called for not scalar replaced object");
-    return _owner_klass;
+    return _owner_klass();
   }
   BasicLock* lock()  const { return _lock;  }
   bool eliminated()  const { return _eliminated; }

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -586,6 +586,7 @@ StackFrameInfo::StackFrameInfo(javaVFrame* jvf, bool with_lock_info) {
   _locked_monitors = NULL;
   if (with_lock_info) {
     ResourceMark rm;
+    HandleMark hm;
     GrowableArray<MonitorInfo*>* list = jvf->locked_monitors();
     int length = list->length();
     if (length > 0) {


### PR DESCRIPTION
Please review this JDK-15u open change that contains the same JDK-15 backport of JDK-9249192 that was pushed into a closed JDK-15u repo.  Pushing the same change into the open JDK-15u increases the availability of this fix to the open community without complicating merging with the closed repo.

Note that the fix for JDK-825118, in JDK-16, was to remove the HandleMark from biasedLocking.cpp that was added as part of the JDK-16 fix for JDK-8249192.  But, this backport of JDK-8249192, doesn't contain the new HandleMark in biasedLocking.cpp.  So, no JDK-15u backport of JDK-825118 is needed because there is no HandleMark to remove.

This backport was tested with tiers 1 and 2 on Linux, Windows, and MacOS, and tiers 3-5 on Linux x64.

Thanks, Harold