### PR TITLE
Backport cc3417dc32e3cfb582ef261bdb684f59449b19ae

### DIFF
--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1804,7 +1804,7 @@ void VMError::controlled_crash(int how) {
   char * const dataPtr = NULL;  // bad data pointer
   const void (*funcPtr)(void);  // bad function pointer
 
-#if defined(PPC64) && !defined(ABI_ELFv2)
+#if defined(PPC64) && !defined(ABI_ELFv2) && !defined(ZERO)
   struct FunctionDescriptor functionDescriptor;
 
   functionDescriptor.set_entry((address) 0xF);


### PR DESCRIPTION
This unbreaks PPC64 Zero.

Additional test:
 - [x] Linux PPC64 Zero cross-compilation